### PR TITLE
Support external injections

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,10 +5,10 @@
 			"name": "Launch tests",
 			"type": "node",
 			"request": "launch",
-			"program": "./node_modules/gulp/bin/gulp.js",
+			"program": "${workspaceRoot}/node_modules/gulp/bin/gulp.js",
 			"stopOnEntry": false,
 			"args": [ "test" ],
-			"cwd": ".",
+			"cwd": "${workspaceRoot}",
 			"runtimeExecutable": null,
 			"runtimeArgs": ["--nolazy"],
 			"env": {

--- a/release/main.d.ts
+++ b/release/main.d.ts
@@ -9,6 +9,7 @@ export interface IGrammarLocator {
 	getFilePath(scopeName:string): string;
 	getInjections?(scopeName:string): string[];
 }
+
 /**
  * The registry that will hold all grammars.
  */

--- a/release/main.d.ts
+++ b/release/main.d.ts
@@ -7,8 +7,8 @@
  */
 export interface IGrammarLocator {
 	getFilePath(scopeName:string): string;
+	getInjections?(scopeName:string): string[];
 }
-
 /**
  * The registry that will hold all grammars.
  */

--- a/release/main.js
+++ b/release/main.js
@@ -93,7 +93,7 @@ var RegexSource = (function () {
         });
     };
     return RegexSource;
-})();
+}());
 exports.RegexSource = RegexSource;
 
 });
@@ -334,7 +334,7 @@ var AsyncGrammarReader = (function () {
         });
     };
     return AsyncGrammarReader;
-})();
+}());
 var SyncGrammarReader = (function () {
     function SyncGrammarReader(filePath, parser) {
         this._filePath = filePath;
@@ -345,7 +345,7 @@ var SyncGrammarReader = (function () {
         return this._parser(contents.toString());
     };
     return SyncGrammarReader;
-})();
+}());
 function getGrammarParser(filePath) {
     if (/\.json$/.test(filePath)) {
         return parseJSONGrammar;
@@ -405,7 +405,7 @@ var Rule = (function () {
         throw new Error('Implement me!');
     };
     return Rule;
-})();
+}());
 exports.Rule = Rule;
 var CaptureRule = (function (_super) {
     __extends(CaptureRule, _super);
@@ -414,7 +414,7 @@ var CaptureRule = (function (_super) {
         this.retokenizeCapturedWithRuleId = retokenizeCapturedWithRuleId;
     }
     return CaptureRule;
-})(Rule);
+}(Rule));
 exports.CaptureRule = CaptureRule;
 var RegExpSource = (function () {
     function RegExpSource(regExpSource, ruleId, handleAnchors) {
@@ -447,7 +447,7 @@ var RegExpSource = (function () {
     };
     RegExpSource.prototype._handleAnchors = function (regExpSource) {
         if (regExpSource) {
-            var pos, len, ch, nextCh, lastPushedPos = 0, output = [];
+            var pos = void 0, len = void 0, ch = void 0, nextCh = void 0, lastPushedPos = 0, output = [];
             var hasAnchor = false;
             for (pos = 0, len = regExpSource.length; pos < len; pos++) {
                 ch = regExpSource.charAt(pos);
@@ -556,7 +556,7 @@ var RegExpSource = (function () {
         }
     };
     return RegExpSource;
-})();
+}());
 exports.RegExpSource = RegExpSource;
 var getOnigModule = (function () {
     var onigurumaModule = null;
@@ -659,7 +659,7 @@ var RegExpSourceList = (function () {
         };
     };
     return RegExpSourceList;
-})();
+}());
 exports.RegExpSourceList = RegExpSourceList;
 var MatchRule = (function (_super) {
     __extends(MatchRule, _super);
@@ -680,7 +680,7 @@ var MatchRule = (function (_super) {
         return this._cachedCompiledPatterns.compile(grammar, allowA, allowG);
     };
     return MatchRule;
-})(Rule);
+}(Rule));
 exports.MatchRule = MatchRule;
 var IncludeOnlyRule = (function (_super) {
     __extends(IncludeOnlyRule, _super);
@@ -705,7 +705,7 @@ var IncludeOnlyRule = (function (_super) {
         return this._cachedCompiledPatterns.compile(grammar, allowA, allowG);
     };
     return IncludeOnlyRule;
-})(Rule);
+}(Rule));
 exports.IncludeOnlyRule = IncludeOnlyRule;
 function escapeRegExpCharacters(value) {
     return value.replace(/[\-\\\{\}\*\+\?\|\^\$\.\,\[\]\(\)\#\s]/g, '\\$&');
@@ -729,7 +729,7 @@ var BeginEndRule = (function (_super) {
     };
     BeginEndRule.prototype.collectPatternsRecursive = function (grammar, out, isFirst) {
         if (isFirst) {
-            var i, len, rule;
+            var i = void 0, len = void 0, rule = void 0;
             for (i = 0, len = this.patterns.length; i < len; i++) {
                 rule = grammar.getRule(this.patterns[i]);
                 rule.collectPatternsRecursive(grammar, out, false);
@@ -765,7 +765,7 @@ var BeginEndRule = (function (_super) {
         return this._cachedCompiledPatterns;
     };
     return BeginEndRule;
-})(Rule);
+}(Rule));
 exports.BeginEndRule = BeginEndRule;
 var RuleFactory = (function () {
     function RuleFactory() {
@@ -898,7 +898,7 @@ var RuleFactory = (function () {
         };
     };
     return RuleFactory;
-})();
+}());
 exports.RuleFactory = RuleFactory;
 
 });
@@ -958,10 +958,9 @@ function _extractIncludedScopesInRepository(result, repository) {
     }
 }
 /**
- * Return a list of all external included scopes in `grammar`.
+ * Collects the list of all external included scopes in `grammar`.
  */
-function extractIncludedScopes(grammar) {
-    var result = {};
+function collectIncludedScopes(result, grammar) {
     if (grammar.patterns && Array.isArray(grammar.patterns)) {
         _extractIncludedScopesInPatterns(result, grammar.patterns);
     }
@@ -970,39 +969,32 @@ function extractIncludedScopes(grammar) {
     }
     // remove references to own scope (avoid recursion)
     delete result[grammar.scopeName];
-    return Object.keys(result);
 }
-exports.extractIncludedScopes = extractIncludedScopes;
-function getGrammarInjections(grammar, ruleFactoryHelper) {
-    var injections = [];
-    var rawInjections = grammar.injections;
-    if (rawInjections) {
-        var nameMatcher = function (identifers, stackElements) {
-            var lastIndex = 0;
-            return identifers.every(function (identifier) {
-                for (var i = lastIndex; i < stackElements.length; i++) {
-                    if (stackElements[i].matches(identifier)) {
-                        lastIndex = i;
-                        return true;
-                    }
+exports.collectIncludedScopes = collectIncludedScopes;
+function collectInjections(result, selector, rule, ruleFactoryHelper, grammar) {
+    function nameMatcher(identifers, stackElements) {
+        var lastIndex = 0;
+        return identifers.every(function (identifier) {
+            for (var i = lastIndex; i < stackElements.length; i++) {
+                if (stackElements[i].matches(identifier)) {
+                    lastIndex = i;
+                    return true;
                 }
-                return false;
-            });
-        };
-        for (var expression in rawInjections) {
-            var subExpressions = expression.split(',');
-            subExpressions.forEach(function (subExpression) {
-                var expressionString = subExpression.replace(/L:/g, '');
-                injections.push({
-                    matcher: matcher_1.createMatcher(expressionString, nameMatcher),
-                    ruleId: rule_1.RuleFactory.getCompiledRuleId(rawInjections[expression], ruleFactoryHelper, grammar.repository),
-                    grammar: grammar,
-                    priorityMatch: expressionString.length < subExpression.length
-                });
-            });
-        }
+            }
+            return false;
+        });
     }
-    return injections;
+    ;
+    var subExpressions = selector.split(',');
+    subExpressions.forEach(function (subExpression) {
+        var expressionString = subExpression.replace(/L:/g, '');
+        result.push({
+            matcher: matcher_1.createMatcher(expressionString, nameMatcher),
+            ruleId: rule_1.RuleFactory.getCompiledRuleId(rule, ruleFactoryHelper, grammar.repository),
+            grammar: grammar,
+            priorityMatch: expressionString.length < subExpression.length
+        });
+    });
 }
 var Grammar = (function () {
     function Grammar(grammar, grammarRepository) {
@@ -1014,8 +1006,31 @@ var Grammar = (function () {
         this._grammar = initGrammar(grammar, null);
     }
     Grammar.prototype.getInjections = function (states) {
+        var _this = this;
         if (!this._injections) {
-            this._injections = getGrammarInjections(this._grammar, this);
+            this._injections = [];
+            // add injections from the current grammar
+            var rawInjections = this._grammar.injections;
+            if (rawInjections) {
+                for (var expression in rawInjections) {
+                    collectInjections(this._injections, expression, rawInjections[expression], this, this._grammar);
+                }
+            }
+            // add injection grammars contributed for the current scope
+            if (this._grammarRepository) {
+                var injectionScopeNames = this._grammarRepository.injections(this._grammar.scopeName);
+                if (injectionScopeNames) {
+                    injectionScopeNames.forEach(function (injectionScopeName) {
+                        var injectionGrammar = _this.getExternalGrammar(injectionScopeName);
+                        if (injectionGrammar) {
+                            var selector = injectionGrammar.injectionSelector;
+                            if (selector) {
+                                collectInjections(_this._injections, selector, injectionGrammar, _this, injectionGrammar);
+                            }
+                        }
+                    });
+                }
+            }
         }
         if (this._injections.length === 0) {
             return this._injections;
@@ -1040,7 +1055,7 @@ var Grammar = (function () {
             var rawIncludedGrammar = this._grammarRepository.lookup(scopeName);
             if (rawIncludedGrammar) {
                 // console.log('LOADED GRAMMAR ' + pattern.include);
-                this._includedGrammars[scopeName] = initGrammar(rawIncludedGrammar, repository.$base);
+                this._includedGrammars[scopeName] = initGrammar(rawIncludedGrammar, repository && repository.$base);
                 return this._includedGrammars[scopeName];
             }
         }
@@ -1072,7 +1087,7 @@ var Grammar = (function () {
         };
     };
     return Grammar;
-})();
+}());
 function initGrammar(grammar, base) {
     grammar = utils_1.clone(grammar);
     grammar.repository = grammar.repository || {};
@@ -1307,7 +1322,7 @@ var StackElement = (function () {
         return this.scopeName.length > len && this.scopeName.substr(0, len) === scopeName && this.scopeName[len] === '.';
     };
     return StackElement;
-})();
+}());
 exports.StackElement = StackElement;
 var LocalStackElement = (function () {
     function LocalStackElement(scopeName, endPos) {
@@ -1315,7 +1330,7 @@ var LocalStackElement = (function () {
         this.endPos = endPos;
     }
     return LocalStackElement;
-})();
+}());
 var LineTokens = (function () {
     function LineTokens() {
         this._tokens = [];
@@ -1362,7 +1377,7 @@ var LineTokens = (function () {
         return this._tokens;
     };
     return LineTokens;
-})();
+}());
 
 });
 $load('./registry', function(require, module, exports) {
@@ -1375,19 +1390,34 @@ var SyncRegistry = (function () {
     function SyncRegistry() {
         this._grammars = {};
         this._rawGrammars = {};
+        this._injectionGrammars = {};
     }
     /**
      * Add `grammar` to registry and return a list of referenced scope names
      */
-    SyncRegistry.prototype.addGrammar = function (grammar) {
+    SyncRegistry.prototype.addGrammar = function (grammar, injectionScopeNames) {
         this._rawGrammars[grammar.scopeName] = grammar;
-        return grammar_1.extractIncludedScopes(grammar);
+        var includedScopes = {};
+        grammar_1.collectIncludedScopes(includedScopes, grammar);
+        if (injectionScopeNames) {
+            this._injectionGrammars[grammar.scopeName] = injectionScopeNames;
+            injectionScopeNames.forEach(function (scopeName) {
+                includedScopes[scopeName] = true;
+            });
+        }
+        return Object.keys(includedScopes);
     };
     /**
      * Lookup a raw grammar.
      */
     SyncRegistry.prototype.lookup = function (scopeName) {
         return this._rawGrammars[scopeName];
+    };
+    /**
+     * Returns the injections for the given grammar
+     */
+    SyncRegistry.prototype.injections = function (targetScope) {
+        return this._injectionGrammars[targetScope];
     };
     /**
      * Lookup a grammar.
@@ -1403,7 +1433,7 @@ var SyncRegistry = (function () {
         return this._grammars[scopeName];
     };
     return SyncRegistry;
-})();
+}());
 exports.SyncRegistry = SyncRegistry;
 
 });
@@ -1417,7 +1447,8 @@ var grammarReader_1 = require('./grammarReader');
 var expressionMatcher = require('./matcher');
 exports.createMatcher = expressionMatcher.createMatcher;
 var DEFAULT_LOCATOR = {
-    getFilePath: function (scopeName) { return null; }
+    getFilePath: function (scopeName) { return null; },
+    getInjections: function (scopeName) { return null; }
 };
 var Registry = (function () {
     function Registry(locator) {
@@ -1465,7 +1496,8 @@ var Registry = (function () {
             }
             try {
                 var grammar = grammarReader_1.readGrammarSync(filePath);
-                var deps = this._syncRegistry.addGrammar(grammar);
+                var injections = this._locator.getInjections(scopeName);
+                var deps = this._syncRegistry.addGrammar(grammar, injections);
                 deps.forEach(function (dep) {
                     if (!seenScopeNames[dep]) {
                         seenScopeNames[dep] = true;
@@ -1484,14 +1516,15 @@ var Registry = (function () {
     };
     Registry.prototype.loadGrammarFromPathSync = function (path) {
         var rawGrammar = grammarReader_1.readGrammarSync(path);
-        this._syncRegistry.addGrammar(rawGrammar);
+        var injections = this._locator.getInjections(rawGrammar.scopeName);
+        this._syncRegistry.addGrammar(rawGrammar, injections);
         return this.grammarForScopeName(rawGrammar.scopeName);
     };
     Registry.prototype.grammarForScopeName = function (scopeName) {
         return this._syncRegistry.grammarForScopeName(scopeName);
     };
     return Registry;
-})();
+}());
 exports.Registry = Registry;
 
 });

--- a/release/main.js
+++ b/release/main.js
@@ -1496,7 +1496,7 @@ var Registry = (function () {
             }
             try {
                 var grammar = grammarReader_1.readGrammarSync(filePath);
-                var injections = this._locator.getInjections(scopeName);
+                var injections = (typeof this._locator.getInjections === 'function') && this._locator.getInjections(scopeName);
                 var deps = this._syncRegistry.addGrammar(grammar, injections);
                 deps.forEach(function (dep) {
                     if (!seenScopeNames[dep]) {

--- a/release/tests/tests.js
+++ b/release/tests/tests.js
@@ -12,13 +12,18 @@ function runDescriptiveTests(testLocation) {
     errCnt = 0;
     tests.forEach(function (test, index) {
         var desc = test.desc;
-        if (test.feature === 'external-injection') {
-            console.log(index + ' - SKIPPING TEST ' + desc + ': injection');
-            return;
-        }
         var noAsserts = (test.feature === 'endless-loop');
         console.log(index + ' - RUNNING ' + desc);
-        var registry = new main_1.Registry();
+        var locator = {
+            getFilePath: function (scopeName) { return null; },
+            getInjections: function (scopeName) {
+                if (scopeName === test.grammarScopeName) {
+                    return test.grammarInjections;
+                }
+                return void 0;
+            }
+        };
+        var registry = new main_1.Registry(locator);
         var grammar = null;
         test.grammars.forEach(function (grammarPath) {
             var tmpGrammar = registry.loadGrammarFromPathSync(path.join(path.dirname(testLocation), grammarPath));

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,7 @@ export import createMatcher = expressionMatcher.createMatcher;
 
 export interface IGrammarLocator {
 	getFilePath(scopeName:string): string;
+	getInjections?(scopeName:string): string[];
 }
 
 export interface IGrammarInfo {
@@ -26,7 +27,8 @@ interface IBarrier {
 }
 
 let DEFAULT_LOCATOR:IGrammarLocator = {
-	getFilePath: (scopeName:string) => null
+	getFilePath: (scopeName:string) => null,
+	getInjections: (scopeName:string) => null
 };
 
 export class Registry {
@@ -87,8 +89,9 @@ export class Registry {
 
 			try {
 				let grammar = readGrammarSync(filePath);
+				let injections = this._locator.getInjections(scopeName);
 
-				let deps = this._syncRegistry.addGrammar(grammar);
+				let deps = this._syncRegistry.addGrammar(grammar, injections);
 				deps.forEach((dep) => {
 					if (!seenScopeNames[dep]) {
 						seenScopeNames[dep] = true;
@@ -108,7 +111,8 @@ export class Registry {
 
 	public loadGrammarFromPathSync(path:string): IGrammar {
 		let rawGrammar = readGrammarSync(path);
-		this._syncRegistry.addGrammar(rawGrammar);
+		let injections = this._locator.getInjections(rawGrammar.scopeName);
+		this._syncRegistry.addGrammar(rawGrammar, injections);
 		return this.grammarForScopeName(rawGrammar.scopeName);
 	}
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -89,7 +89,7 @@ export class Registry {
 
 			try {
 				let grammar = readGrammarSync(filePath);
-				let injections = this._locator.getInjections(scopeName);
+				let injections = (typeof this._locator.getInjections === 'function') && this._locator.getInjections(scopeName);
 
 				let deps = this._syncRegistry.addGrammar(grammar, injections);
 				deps.forEach((dep) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,7 @@ export interface IRawGrammar {
 	scopeName: string;
 	patterns: IRawRule[];
 	injections?: { [expression:string]: IRawRule };
+	injectionSelector?: string;
 
 	fileTypes?: string[];
 	name?: string;

--- a/src/typings/main.d.ts
+++ b/src/typings/main.d.ts
@@ -7,6 +7,7 @@
  */
 export interface IGrammarLocator {
 	getFilePath(scopeName:string): string;
+	getInjections?(scopeName:string): string[];
 }
 
 /**

--- a/test-cases/first-mate/tests.json
+++ b/test-cases/first-mate/tests.json
@@ -3278,6 +3278,7 @@
 	},
 	{
 		"grammarScopeName": "source.js",
+		"grammarInjections": ["text.hyperlink"],
 		"lines": [
 			{
 				"line": "var i; // http://github.com",
@@ -3354,8 +3355,7 @@
 			"fixtures/python-regex.json",
 			"fixtures/hyperlink.json"
 		],
-		"desc": "TEST #47",
-		"feature": "external-injection"
+		"desc": "TEST #47"
 	},
 	{
 		"grammarPath": "fixtures/forever.json",
@@ -3382,6 +3382,7 @@
 	},
 	{
 		"grammarScopeName": "source.ruby",
+		"grammarInjections": ["text.todo"],
 		"lines": [
 			{
 				"line": "# TODO be nicer",
@@ -3439,8 +3440,7 @@
 			"fixtures/python-regex.json",
 			"fixtures/todo.json"
 		],
-		"desc": "TEST #49",
-		"feature": "external-injection"
+		"desc": "TEST #49"
 	},
 	{
 		"grammarScopeName": "source.makefile",


### PR DESCRIPTION
The pull requests adds support for external injection grammars. Injection grammars look like regular grammars, with a scope name as identifier, but have the property 'injectionSelector'.

In text mate, injection grammars are applied to all grammars. I changed that in our implementation: 
We only use the injection grammars that are configured for the current language scope. The goal of this limitation is to avoid a performance regression due to many injections in the system.

The new API `getInjections` on the `IGrammarLocator` takes a language scope (e.g. 'source.js') and returns the grammar identifiers of all injection grammars to apply (e.g. [ 'text.todo', 'text.hyperlink']).
This API will be implemented on the client side (in VSCode). The idea is that each contributed injection grammar also specifies a list of grammar it applies to.

https://github.com/Microsoft/vscode/issues/6331 is the pull request on the VS Code side.