### PR TITLE
Support for grammars with begin/while rules

### DIFF
--- a/release/main.d.ts
+++ b/release/main.d.ts
@@ -73,6 +73,7 @@ export interface StackElement {
 	ruleId: number;
 	enterPos: number;
 	endRule: string;
+	whileRule: string;
 	scopeName: string;
 	contentName: string;
 

--- a/release/main.js
+++ b/release/main.js
@@ -1216,7 +1216,7 @@ function matchInjections(injections, grammar, lineText, isFirstLine, linePos, st
 function matchRule(grammar, lineText, isFirstLine, linePos, stack, anchorPosition) {
     var stackElement = stack[stack.length - 1];
     var rule = grammar.getRule(stackElement.ruleId);
-    if (rule instanceof rule_1.BeginWhileRule) {
+    if (rule instanceof rule_1.BeginWhileRule && stackElement.enterPos === -1) {
         var ruleScanner_1 = rule.compileWhile(grammar, stackElement.endRule || stackElement.whileRule, isFirstLine, linePos === anchorPosition);
         var r_1 = ruleScanner_1.scanner._findNextMatchSync(lineText, linePos);
         var doNotContinue = {

--- a/src/grammar.ts
+++ b/src/grammar.ts
@@ -372,7 +372,7 @@ function matchRule(grammar: Grammar, lineText: OnigString, isFirstLine: boolean,
 	let stackElement = stack[stack.length - 1];
 	let rule = grammar.getRule(stackElement.ruleId);
 
-	if (rule instanceof BeginWhileRule) {
+	if (rule instanceof BeginWhileRule && stackElement.enterPos === -1) {
 
 		let ruleScanner = rule.compileWhile(grammar, stackElement.endRule || stackElement.whileRule, isFirstLine, linePos === anchorPosition);
 		let r = ruleScanner.scanner._findNextMatchSync(lineText, linePos);

--- a/src/grammar.ts
+++ b/src/grammar.ts
@@ -5,7 +5,7 @@
 
 import {clone} from './utils';
 import {IRawGrammar, IRawRepository, IRawRule} from './types';
-import {IRuleFactoryHelper, RuleFactory, Rule, CaptureRule, BeginEndRule, MatchRule, ICompiledRule, createOnigString, getString} from './rule';
+import {IRuleFactoryHelper, RuleFactory, Rule, CaptureRule, BeginEndRule, BeginWhileRule, MatchRule, ICompiledRule, createOnigString, getString} from './rule';
 import {IOnigCaptureIndex, IOnigNextMatchResult, OnigString} from 'oniguruma';
 import {createMatcher, Matcher} from './matcher';
 
@@ -370,7 +370,31 @@ interface IMatchResult {
 
 function matchRule(grammar: Grammar, lineText: OnigString, isFirstLine: boolean, linePos: number, stack: StackElement[], anchorPosition:number): IMatchResult {
 	let stackElement = stack[stack.length - 1];
-	let ruleScanner = grammar.getRule(stackElement.ruleId).compile(grammar, stackElement.endRule, isFirstLine, linePos === anchorPosition);
+	let rule = grammar.getRule(stackElement.ruleId);
+
+	if (rule instanceof BeginWhileRule) {
+
+		let ruleScanner = rule.compileWhile(grammar, stackElement.endRule || stackElement.whileRule, isFirstLine, linePos === anchorPosition);
+		let r = ruleScanner.scanner._findNextMatchSync(lineText, linePos);
+
+		let doNotContinue: IMatchResult = {
+			captureIndices: null,
+			matchedRuleId: -3
+		};
+
+		if (r) {
+			let matchedRuleId = ruleScanner.rules[r.index];
+			if (matchedRuleId != -2) {
+				// we shouldn't end up here
+				return doNotContinue;
+			}
+		} else {
+			return doNotContinue;
+		}
+	}
+
+
+	let ruleScanner = rule.compile(grammar, stackElement.endRule || stackElement.whileRule, isFirstLine, linePos === anchorPosition);
 	let r = ruleScanner.scanner._findNextMatchSync(lineText, linePos);
 
 	if (r) {
@@ -439,7 +463,7 @@ function _tokenizeString(grammar: Grammar, lineText: OnigString, isFirstLine: bo
 		let captureIndices: IOnigCaptureIndex[] = r.captureIndices;
 		let matchedRuleId: number = r.matchedRuleId;
 
-		let hasAdvanced = (captureIndices[0].end > linePos);
+		let hasAdvanced = (captureIndices && captureIndices.length > 0) ? (captureIndices[0].end > linePos) : false;
 
 		if (matchedRuleId === -1) {
 			// We matched the `end` for this rule => pop it
@@ -460,6 +484,10 @@ function _tokenizeString(grammar: Grammar, lineText: OnigString, isFirstLine: bo
 				linePos = lineLength;
 				return false;
 			}
+		} else if (matchedRuleId === -3) {
+			// A while clause failed
+			stack.pop();
+			return true;
 
 		} else {
 			// We matched a rule!
@@ -468,7 +496,7 @@ function _tokenizeString(grammar: Grammar, lineText: OnigString, isFirstLine: bo
 			lineTokens.produce(stack, captureIndices[0].start);
 
 			// push it on the stack rule
-			stack.push(new StackElement(matchedRuleId, linePos, null, _rule.getName(getString(lineText), captureIndices), null));
+			stack.push(new StackElement(matchedRuleId, linePos, null, _rule.getName(getString(lineText), captureIndices), null, null));
 
 			if (_rule instanceof BeginEndRule) {
 				let pushedRule = <BeginEndRule>_rule;
@@ -480,6 +508,26 @@ function _tokenizeString(grammar: Grammar, lineText: OnigString, isFirstLine: bo
 
 				if (pushedRule.endHasBackReferences) {
 					stack[stack.length-1].endRule = pushedRule.getEndWithResolvedBackReferences(getString(lineText), captureIndices);
+				}
+
+				if (!hasAdvanced && stackElement.ruleId === stack[stack.length - 1].ruleId) {
+					// Grammar pushed the same rule without advancing
+					console.error('Grammar is in an endless loop - case 2');
+					stack.pop();
+					lineTokens.produce(stack, lineLength);
+					linePos = lineLength;
+					return false;
+				}
+			} else if (_rule instanceof BeginWhileRule) {
+				let pushedRule = <BeginWhileRule>_rule;
+
+				handleCaptures(grammar, lineText, isFirstLine, stack, lineTokens, pushedRule.beginCaptures, captureIndices);
+				lineTokens.produce(stack, captureIndices[0].end);
+				anchorPosition = captureIndices[0].end;
+				stack[stack.length - 1].contentName = pushedRule.getContentName(getString(lineText), captureIndices);
+
+				if (pushedRule.whileHasBackReferences) {
+					stack[stack.length - 1].whileRule = pushedRule.getWhileWithResolvedBackReferences(getString(lineText), captureIndices);
 				}
 
 				if (!hasAdvanced && stackElement.ruleId === stack[stack.length - 1].ruleId) {
@@ -527,19 +575,21 @@ export class StackElement {
 	public endRule: string;
 	public scopeName: string;
 	public contentName: string;
+	public whileRule: string;
 
 	private scopeNameSegments: { [segment:string]:boolean };
 
-	constructor (ruleId:number, enterPos:number, endRule:string, scopeName:string, contentName:string) {
+	constructor(ruleId:number, enterPos:number, endRule:string, scopeName:string, contentName: string, whileRule: string = null) {
 		this.ruleId = ruleId;
 		this.enterPos = enterPos;
 		this.endRule = endRule;
 		this.scopeName = scopeName;
 		this.contentName = contentName;
+		this.whileRule = whileRule;
 	}
 
 	public clone(): StackElement {
-		return new StackElement(this.ruleId, this.enterPos, this.endRule, this.scopeName, this.contentName);
+		return new StackElement(this.ruleId, this.enterPos, this.endRule, this.scopeName, this.contentName, this.whileRule);
 	}
 
 	public matches(scopeName: string) : boolean {

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,7 @@ export interface IRawRule {
 	beginCaptures?: IRawCaptures;
 	end?:string;
 	endCaptures?: IRawCaptures;
+	while?:string;
 	patterns?: IRawRule[];
 
 	repository?: IRawRepository;

--- a/src/typings/main.d.ts
+++ b/src/typings/main.d.ts
@@ -73,6 +73,7 @@ export interface StackElement {
 	ruleId: number;
 	enterPos: number;
 	endRule: string;
+	whileRule: string;
 	scopeName: string;
 	contentName: string;
 

--- a/test-cases/suite1/tests.json
+++ b/test-cases/suite1/tests.json
@@ -78,6 +78,18 @@
 		"desc": "Nested repositories in Markdown",
 		"lines": [
 			{
+				"line": "This is a paragraph",
+                "tokens": [
+                    {
+                        "value": "This is a paragraph",
+                        "scopes": [
+                            "text.html.markdown",
+                            "meta.paragraph.markdown"
+                        ]
+                    }
+                ]
+            },
+			{
 				"line": "## This is *great* stuff",
 				"tokens": [
 					{


### PR DESCRIPTION
The old implementation treated begin/while rules as begin/end rules with a missing end clause.

While clauses differ from end clauses in that they are only applied to lines that come after the line on which the begin clause matched.  When a begin/while rule is at the top of the stack and fails the rules is popped off the stack and the line is re-analysed.
 
@alexandrudima  