### PR TITLE
Fix While Rules Being Tested Within Lines Instead of at Start Only

### DIFF
--- a/src/grammar.ts
+++ b/src/grammar.ts
@@ -391,7 +391,8 @@ interface IMatchResult {
 function matchRule(grammar: Grammar, lineText: OnigString, isFirstLine: boolean, linePos: number, stack: StackElement, anchorPosition:number): IMatchResult {
 	let rule = stack.getRule(grammar);
 
-	if (rule instanceof BeginWhileRule && stack.getEnterPos() === -1) {
+	// Check while rule only on new lines after the line containing the begin clause
+	if (rule instanceof BeginWhileRule && stack.getEnterPos() === -1 && linePos === 0) {
 
 		let ruleScanner = rule.compileWhile(grammar, stack.getEndRule(), isFirstLine, linePos === anchorPosition);
 		let r = ruleScanner.scanner._findNextMatchSync(lineText, linePos);

--- a/test-cases/suite1/fixtures/whileLang.plist
+++ b/test-cases/suite1/fixtures/whileLang.plist
@@ -31,7 +31,7 @@
         <key>group</key>
         <dict>
             <key>begin</key>
-			<string>(^)(\()</string>
+            <string>(^)(\()</string>
             <key>patterns</key>
             <array>
                 <dict>

--- a/test-cases/suite1/fixtures/whileLang.plist
+++ b/test-cases/suite1/fixtures/whileLang.plist
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>fileTypes</key>
+    <array>
+        <string>whileLang</string>
+    </array>
+    <key>name</key>
+    <string>whileLang</string>
+    <key>patterns</key>
+    <array>
+        <dict>
+            <key>include</key>
+            <string>#group</string>
+        </dict>
+         <dict>
+            <key>include</key>
+            <string>#number</string>
+        </dict>
+    </array>
+    <key>repository</key>
+    <dict>
+        <key>number</key>
+        <dict>
+            <key>match</key>
+            <string>[0-9]</string>
+            <key>name</key>
+            <string>number</string>
+        </dict>
+        <key>group</key>
+        <dict>
+            <key>begin</key>
+			<string>(^)(\()</string>
+            <key>patterns</key>
+            <array>
+                <dict>
+                    <key>include</key>
+                    <string>#number</string>
+                </dict>
+            </array>
+            <key>name</key>
+            <string>group</string>
+            <key>while</key>
+            <string>(^|\G)(?!\))</string>
+        </dict>
+    </dict>
+    <key>scopeName</key>
+    <string>text.whileLang</string>
+    <key>uuid</key>
+    <string>159375af-d9b4-448c-a9da-d235eadf3556</string>
+</dict>
+</plist>

--- a/test-cases/suite1/tests.json
+++ b/test-cases/suite1/tests.json
@@ -1015,5 +1015,73 @@
 				]
 			}
 		]
+	},
+	{
+		"grammars": [
+			"fixtures/whileLang.plist"
+		],
+		"grammarPath": "fixtures/whileLang.plist",
+		"desc": "TODO",
+		"lines": [
+			{
+				"line": "(1",
+				"tokens": [
+					{
+						"scopes": [
+							"text.whileLang",
+							"group"
+						],
+						"value": "("
+					},
+					{
+						"scopes": [
+							"text.whileLang",
+							"group",
+							"number"
+						],
+						"value": "1"
+					}
+				]
+			},
+			{
+				"line": "23",
+				"tokens": [
+					{
+						"scopes": [
+							"text.whileLang",
+							"group",
+							"number"
+						],
+						"value": "2"
+					},
+					{
+						"scopes": [
+							"text.whileLang",
+							"group",
+							"number"
+						],
+						"value": "3"
+					}
+				]
+			},
+			{
+				"line": ") 4",
+				"tokens": [
+					{
+						"scopes": [
+							"text.whileLang"
+						],
+						"value": ") "
+					},
+					{
+						"scopes": [
+							"text.whileLang",
+							"number"
+						],
+						"value": "4"
+					}
+				]
+			}
+		]
 	}
 ]


### PR DESCRIPTION
**Bug**
In VS Code in the markdown grammar, we see some grammar rules that use `while` stop matching early on the second line of the rule (the line after the begin). The root cause is that the while check clause is being evaluated on both on the start of the second line, and after the first match on the second line.

**Fix**
The while expression should only be checked on lines to determine if the line should be matched or not. Once a line has been matched with while, the entire line becomes part of the group. This fix adds a second condition to the while check so that we only apply it when starting a line.

I also added a simple grammar to test this behavior. It failed to match properly before, but does work properly after the fix.