### PR TITLE
Fix While Rules That Use \G In Pattern

### DIFF
--- a/test-cases/suite1/fixtures/whileLang.plist
+++ b/test-cases/suite1/fixtures/whileLang.plist
@@ -82,14 +82,14 @@
             <string>blist</string>
             <key>whileCaptures</key>
             <dict>
-                <key>1</key>
+                <key>2</key>
                 <dict>
                     <key>name</key>
                     <string>bstart</string>
                 </dict>
             </dict>
             <key>while</key>
-            <string>(b)</string>
+            <string>(^|\G)(b)</string>
         </dict>
     </dict>
     <key>scopeName</key>

--- a/test-cases/suite1/whileTests.json
+++ b/test-cases/suite1/whileTests.json
@@ -421,5 +421,94 @@
 				]
 			}
 		]
+	},
+	{
+		"grammars": [
+			"fixtures/whileLang.plist"
+		],
+		"grammarPath": "fixtures/whileLang.plist",
+		"desc": "Nested whiles should check line for outer most while to inner most while",
+		"lines": [
+			{
+				"line": "AB",
+				"tokens": [
+					{
+						"scopes": [
+							"text.whileLang",
+							"alist"
+						],
+						"value": "A"
+					},
+					{
+						"scopes": [
+							"text.whileLang",
+							"alist",
+							"blist"
+						],
+						"value": "B"
+					}
+				]
+			},
+			{
+				"line": "b1",
+				"tokens": [
+					{
+						"scopes": [
+							"text.whileLang"
+						],
+						"value": "b1"
+					}
+				]
+			}
+		]
+	},
+	{
+		"grammars": [
+			"fixtures/whileLang.plist"
+		],
+		"grammarPath": "fixtures/whileLang.plist",
+		"desc": "Should Correctly handle anchor in while rule",
+		"lines": [
+			{
+				"line": "BB",
+				"tokens": [
+					{
+						"scopes": [
+							"text.whileLang",
+							"blist"
+						],
+						"value": "B"
+					},
+					{
+						"scopes": [
+							"text.whileLang",
+							"blist",
+							"blist"
+						],
+						"value": "B"
+					}
+				]
+			},
+			{
+				"line": "b b",
+				"tokens": [
+					{
+						"scopes": [
+							"text.whileLang",
+							"blist",
+							"bstart"
+						],
+						"value": "b"
+					},
+					{
+						"scopes": [
+							"text.whileLang",
+							"blist"
+						],
+						"value": " b"
+					}
+				]
+			}
+		]
 	}
 ]


### PR DESCRIPTION
**Bug**
In testing the while rules, I found that the while patterns themselves do not handle `\G` anchors. See the update unit tests for an example of a grammar that uses these.

On the VSCode side, this bug shows up after I tried to implement https://github.com/Microsoft/vscode/pull/14626 Specifically, with 14626 but without this fix, fenced code blocks inside of the block quotes are not highlighted because their while rules use `\G`. I suspect there are other cases that are also broken because of this.

**Fix**
Two fixes:
- When compiling the while rule, use the standard logic to determine if we are starting from a previous match.
- Correct handling of `isFirstLine` within while rules to be updated when the rule is advanced.
