### PR TITLE
dispose OnigScanner and OnigString instances if they are disposable

### DIFF
--- a/src/grammar.ts
+++ b/src/grammar.ts
@@ -421,6 +421,7 @@ export class Grammar implements IGrammar, IRuleFactoryHelper {
 		let lineLength = getString(onigLineText).length;
 		let lineTokens = new LineTokens(emitBinaryTokens, lineText);
 		let nextState = _tokenizeString(this, onigLineText, isFirstLine, 0, prevState, lineTokens);
+		if (onigLineText.dispose) { onigLineText.dispose(); }
 
 		return {
 			lineLength: lineLength,
@@ -492,12 +493,12 @@ function handleCaptures(grammar: Grammar, lineText: OnigString, isFirstLine: boo
 			let contentNameScopesList = nameScopesList.push(grammar, contentName);
 
 			let stackClone = stack.push(captureRule.retokenizeCapturedWithRuleId, captureIndex.start, null, nameScopesList, contentNameScopesList);
+			const str = createOnigString(getString(lineText).substring(0, captureIndex.end));
 			_tokenizeString(grammar,
-				createOnigString(
-					getString(lineText).substring(0, captureIndex.end)
-				),
+				str,
 				(isFirstLine && captureIndex.start === 0), captureIndex.start, stackClone, lineTokens
 			);
+			if (str.dispose) { str.dispose(); }
 			continue;
 		}
 

--- a/typings/globals/oniguruma/oniguruma.d.ts
+++ b/typings/globals/oniguruma/oniguruma.d.ts
@@ -16,10 +16,12 @@ declare module "oniguruma" {
 		constructor(regexps:string[]);
 		_findNextMatchSync(lin:string, pos:number): IOnigNextMatchResult;
 		_findNextMatchSync(lin:OnigString, pos:number): IOnigNextMatchResult;
+		dispose?(): void;
 	}
 
 	export class OnigString {
 		constructor(str:string);
+		dispose?(): void;
 	}
 
 }


### PR DESCRIPTION
This enables vscode-textmate to work with alternate implementations of Oniguruma that require (or benefit from) manual memory management. I will be releasing an API-compatible version of node-oniguruma soon that uses Emscripten to compile to pure JavaScript, and it is necessary to dispose OnigStrings to avoid memory leaks.

This PR does not change the behavior or have any measurable performance degradation if OnigString and/or OnigScanner lack a `dispose` method.