### PR TITLE
Add token type map config

### DIFF
--- a/release/main.d.ts
+++ b/release/main.d.ts
@@ -31,11 +31,21 @@ export interface RegistryOptions {
 export interface IEmbeddedLanguagesMap {
     [scopeName: string]: number;
 }
+/**
+ * A map from scope name to a token type.
+ */
+export interface ITokenTypeMap {
+    [scopeName: string]: StandardTokenType;
+}
 export declare const enum StandardTokenType {
     Other = 0,
     Comment = 1,
     String = 2,
     RegEx = 4,
+}
+export interface IGrammarConfiguration {
+    embeddedLanguages?: IEmbeddedLanguagesMap;
+    tokenTypes?: ITokenTypeMap;
 }
 /**
  * The registry that will hold all grammars.
@@ -59,6 +69,11 @@ export declare class Registry {
     loadGrammarWithEmbeddedLanguages(initialScopeName: string, initialLanguage: number, embeddedLanguages: IEmbeddedLanguagesMap, callback: (err: any, grammar: IGrammar) => void): void;
     /**
      * Load the grammar for `scopeName` and all referenced included grammars asynchronously.
+     * Please do not use language id 0.
+     */
+    loadGrammarWithConfiguration(initialScopeName: string, initialLanguage: number, configuration: IGrammarConfiguration, callback: (err: any, grammar: IGrammar) => void): void;
+    /**
+     * Load the grammar for `scopeName` and all referenced included grammars asynchronously.
      */
     loadGrammar(initialScopeName: string, callback: (err: any, grammar: IGrammar) => void): void;
     private _loadGrammar(initialScopeName, callback);
@@ -69,7 +84,7 @@ export declare class Registry {
     /**
      * Get the grammar for `scopeName`. The grammar must first be created via `loadGrammar` or `loadGrammarFromPathSync`.
      */
-    grammarForScopeName(scopeName: string, initialLanguage?: number, embeddedLanguages?: IEmbeddedLanguagesMap): IGrammar;
+    grammarForScopeName(scopeName: string, initialLanguage?: number, embeddedLanguages?: IEmbeddedLanguagesMap, tokenTypes?: ITokenTypeMap): IGrammar;
 }
 /**
  * A grammar

--- a/src/main.ts
+++ b/src/main.ts
@@ -50,11 +50,23 @@ export interface IEmbeddedLanguagesMap {
 	[scopeName: string]: number;
 }
 
+/**
+ * A map from scope name to a token type.
+ */
+export interface ITokenTypeMap {
+	[scopeName: string]: StandardTokenType;
+}
+
 export const enum StandardTokenType {
 	Other = 0,
 	Comment = 1,
 	String = 2,
 	RegEx = 4
+}
+
+export interface IGrammarConfiguration {
+	embeddedLanguages?: IEmbeddedLanguagesMap;
+	tokenTypes?: ITokenTypeMap;
 }
 
 /**
@@ -89,13 +101,21 @@ export class Registry {
 	 * Please do not use language id 0.
 	 */
 	public loadGrammarWithEmbeddedLanguages(initialScopeName: string, initialLanguage: number, embeddedLanguages: IEmbeddedLanguagesMap, callback: (err: any, grammar: IGrammar) => void): void {
+		return this.loadGrammarWithConfiguration(initialScopeName, initialLanguage, { embeddedLanguages }, callback)
+	}
+
+	/**
+	 * Load the grammar for `scopeName` and all referenced included grammars asynchronously.
+	 * Please do not use language id 0.
+	 */
+	public loadGrammarWithConfiguration(initialScopeName: string, initialLanguage: number, configuration: IGrammarConfiguration, callback: (err: any, grammar: IGrammar) => void): void {
 		this._loadGrammar(initialScopeName, (err) => {
 			if (err) {
 				callback(err, null);
 				return;
 			}
 
-			callback(null, this.grammarForScopeName(initialScopeName, initialLanguage, embeddedLanguages));
+			callback(null, this.grammarForScopeName(initialScopeName, initialLanguage, configuration.embeddedLanguages, configuration.tokenTypes));
 		});
 	}
 
@@ -171,8 +191,8 @@ export class Registry {
 	/**
 	 * Get the grammar for `scopeName`. The grammar must first be created via `loadGrammar` or `loadGrammarFromPathSync`.
 	 */
-	public grammarForScopeName(scopeName: string, initialLanguage: number = 0, embeddedLanguages: IEmbeddedLanguagesMap = null): IGrammar {
-		return this._syncRegistry.grammarForScopeName(scopeName, initialLanguage, embeddedLanguages);
+	public grammarForScopeName(scopeName: string, initialLanguage: number = 0, embeddedLanguages: IEmbeddedLanguagesMap = null, tokenTypes: ITokenTypeMap = null): IGrammar {
+		return this._syncRegistry.grammarForScopeName(scopeName, initialLanguage, embeddedLanguages, tokenTypes);
 	}
 }
 

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -5,7 +5,7 @@
 
 import { createGrammar, Grammar, collectIncludedScopes, IGrammarRepository, IScopeNameSet } from './grammar';
 import { IRawGrammar } from './types';
-import { IGrammar, IEmbeddedLanguagesMap } from './main';
+import { IGrammar, IEmbeddedLanguagesMap, ITokenTypeMap } from './main';
 import { Theme, ThemeTrieElementRule } from './theme';
 
 export class SyncRegistry implements IGrammarRepository {
@@ -84,14 +84,14 @@ export class SyncRegistry implements IGrammarRepository {
 	/**
 	 * Lookup a grammar.
 	 */
-	public grammarForScopeName(scopeName: string, initialLanguage: number, embeddedLanguages: IEmbeddedLanguagesMap): IGrammar {
+	public grammarForScopeName(scopeName: string, initialLanguage: number, embeddedLanguages: IEmbeddedLanguagesMap, tokenTypes: ITokenTypeMap): IGrammar {
 		if (!this._grammars[scopeName]) {
 			let rawGrammar = this._rawGrammars[scopeName];
 			if (!rawGrammar) {
 				return null;
 			}
 
-			this._grammars[scopeName] = createGrammar(rawGrammar, initialLanguage, embeddedLanguages, this);
+			this._grammars[scopeName] = createGrammar(rawGrammar, initialLanguage, embeddedLanguages, tokenTypes, this);
 		}
 		return this._grammars[scopeName];
 	}


### PR DESCRIPTION
Fixes #60

Adds a basic map that allows library consumers to override the token type of a given scope. See  #60 for more details