### PR TITLE
Pop only highest instance of While Rule

### DIFF
--- a/src/rule.ts
+++ b/src/rule.ts
@@ -529,6 +529,14 @@ export class BeginWhileRule extends Rule {
 		this._cachedCompiledWhilePatterns = null;
 	}
 
+	public get debugBeginRegExp(): string {
+		return `${this._begin.source}`;
+	}
+
+	public get debugWhileRegExp(): string {
+		return `${this._while.source}`;
+	}
+
 	public getWhileWithResolvedBackReferences(lineText: string, captureIndices: IOnigCaptureIndex[]): string {
 		return this._while.resolveBackReferences(lineText, captureIndices);
 	}


### PR DESCRIPTION
A proposed fix for while rule checking.  It would seem that TextMate only pops off the highest instance of of a given rule, even though the rules are checked from the bottom up.

To reiterate my comment in the issue, this PR implements point 2:
1. On a new line, check all while conditions from bottom of the stack to the top.
2. For each while condition that fails:
   1. Search stack from top to bottom for another instance of the same while condition.
   2. Pop everything after and including the first (highest) instance found.
   3. Continue checking remaining while conditions.

I also added debugging output that has been missing for the while rules checking process.

Fix #110