### PR TITLE
Add debugging to While Rule popping

### DIFF
--- a/src/grammar.ts
+++ b/src/grammar.ts
@@ -739,6 +739,10 @@ function _checkWhileConditions(grammar: Grammar, lineText: OnigString, isFirstLi
 				}
 			}
 		} else {
+			if (DebugFlags.InDebugMode) {
+				console.log('  popping ' + whileRule.rule.debugName + ' - ' + whileRule.rule.debugWhileRegExp);
+			}
+
 			stack = whileRule.stack.pop();
 			break;
 		}

--- a/src/rule.ts
+++ b/src/rule.ts
@@ -529,6 +529,14 @@ export class BeginWhileRule extends Rule {
 		this._cachedCompiledWhilePatterns = null;
 	}
 
+	public get debugBeginRegExp(): string {
+		return `${this._begin.source}`;
+	}
+
+	public get debugWhileRegExp(): string {
+		return `${this._while.source}`;
+	}
+
 	public getWhileWithResolvedBackReferences(lineText: string, captureIndices: IOnigCaptureIndex[]): string {
 		return this._while.resolveBackReferences(lineText, captureIndices);
 	}


### PR DESCRIPTION
Add debug print to While condition popping, add support functions needed
to BeginWhileRule class.

This makes debugging with BeginWhileRules just a bit easier.  It makes it definitive which While rule popped, if any, and makes the debug output more consistent.