### PR TITLE
Improve endless loop detection

### DIFF
--- a/src/grammar.ts
+++ b/src/grammar.ts
@@ -961,7 +961,7 @@ function _tokenizeString(grammar: Grammar, lineText: OnigString, isFirstLine: bo
 					stack = stack.setEndRule(pushedRule.getEndWithResolvedBackReferences(lineText.content, captureIndices));
 				}
 
-				if (!hasAdvanced && beforePush.hasSameRuleAs(stack)) {
+				if (stack.hasEndlessLoop(anchorPosition)) {
 					// Grammar pushed the same rule without advancing
 					if (DebugFlags.InDebugMode) {
 						console.error('[2] - Grammar is in an endless loop - Grammar pushed the same rule without advancing');
@@ -988,7 +988,7 @@ function _tokenizeString(grammar: Grammar, lineText: OnigString, isFirstLine: bo
 					stack = stack.setEndRule(pushedRule.getWhileWithResolvedBackReferences(lineText.content, captureIndices));
 				}
 
-				if (!hasAdvanced && beforePush.hasSameRuleAs(stack)) {
+				if (stack.hasEndlessLoop(anchorPosition)) {
 					// Grammar pushed the same rule without advancing
 					if (DebugFlags.InDebugMode) {
 						console.error('[3] - Grammar is in an endless loop - Grammar pushed the same rule without advancing');
@@ -1435,6 +1435,24 @@ export class StackElement implements StackElementDef {
 
 	public hasSameRuleAs(other: StackElement): boolean {
 		return this.ruleId === other.ruleId;
+	}
+
+	public hasEndlessLoop(anchorPosition: number): boolean {
+		if (anchorPosition === -1) {
+			// method is unavailable
+			return true;
+		}
+
+		let se = this as StackElement;
+
+		while (anchorPosition === se._anchorPos && se.parent !== null) {
+			se = se.parent;
+			if (this.hasSameRuleAs(se)) {
+				// endless loop detected
+				return true;
+			}
+		}
+		return false;
 	}
 }
 

--- a/test-cases/suite1/fixtures/infinite-loop.json
+++ b/test-cases/suite1/fixtures/infinite-loop.json
@@ -1,0 +1,79 @@
+{
+	"name": "infinite-loop-grammar",
+	"scopeName": "source.infinite-loop",
+	"patterns": [
+		{
+			"name": "start",
+			"begin": "\\A",
+			"end": "$",
+			"patterns": [
+				{
+					"name": "negative-look-ahead",
+					"match": "(?!a)"
+				}
+			]
+		},
+		{
+			"include": "#test"
+		},
+		{
+			"include": "#not_a_problem"
+		}
+	],
+	"repository": {
+		"test": {
+			"name": "test",
+			"begin": "(?=test)",
+			"end": "$",
+			"patterns": [
+				{
+					"include": "#test_this"
+				}
+			]
+		},
+		"test_this": {
+			"name": "test_this",
+			"begin": "(?=test this)",
+			"end": "$",
+			"patterns": [
+				{
+					"include": "#test_this_line"
+				}
+			]
+		},
+		"test_this_line": {
+			"name": "test_this_line",
+			"begin": "(?=test this line)",
+			"end": "$",
+			"patterns": [
+				{
+					"include": "#test"
+				}
+			]
+		},
+		"spaces":
+		{
+			"name": "spaces",
+			"begin": "^(?=\\s)",
+			"end": "(?=\\S)"
+		},
+		"not_a_problem":
+		{
+			"name": "not_a_problem",
+			"begin": "(?=not)",
+			"end": "\\z",
+			"patterns": [
+				{
+					"name": "not",
+					"match": "\\Gnot"
+				},
+				{
+					"include": "#not_a_problem"
+				},
+				{
+					"include": "#spaces"
+				}
+			]
+		}
+	}
+}

--- a/test-cases/suite1/tests.json
+++ b/test-cases/suite1/tests.json
@@ -1710,5 +1710,101 @@
 				]
 			}
 		]
+	},
+	{
+		"grammars": [
+			"fixtures/infinite-loop.json"
+		],
+		"grammarPath": "fixtures/infinite-loop.json",
+		"desc": "Issue #145",
+		"lines": [
+			{
+				"line": "abc",
+				"tokens": [
+					{
+						"value": "a",
+						"scopes": [
+							"source.infinite-loop",
+							"start"
+						]
+					},
+					{
+						"value": "bc",
+						"scopes": [
+							"source.infinite-loop"
+						]
+					}
+				]
+			},
+			{
+				"line": "test this line",
+				"tokens": [
+					{
+						"value": "test this line",
+						"scopes": [
+							"source.infinite-loop",
+							"test",
+							"test_this",
+							"test_this_line"
+						]
+					}
+				]
+			},
+			{
+				"line": "not",
+				"tokens": [
+					{
+						"value": "not",
+						"scopes": [
+							"source.infinite-loop",
+							"test",
+							"test_this",
+							"test_this_line"
+						]
+					}
+				]
+			},
+			{
+				"line": "    not",
+				"tokens": [
+					{
+						"value": "    ",
+						"scopes": [
+							"source.infinite-loop"
+						]
+					},
+					{
+						"value": "not",
+						"scopes": [
+							"source.infinite-loop",
+							"not_a_problem",
+							"not"
+						]
+					}
+				]
+			},
+			{
+				"line": "        not",
+				"tokens": [
+					{
+						"value": "        ",
+						"scopes": [
+							"source.infinite-loop",
+							"not_a_problem",
+							"spaces"
+						]
+					},
+					{
+						"value": "not",
+						"scopes": [
+							"source.infinite-loop",
+							"not_a_problem",
+							"not_a_problem",
+							"not"
+						]
+					}
+				]
+			}
+		]
 	}
 ]


### PR DESCRIPTION
Presenting a solution for endless loop detection that catches endless loops that occur over multiple Begin/End or Begin/While rules, while preventing falsely flagging rules that appear to be endless loops due to the same rule as last stacked matching with a zero length capture condition.

Included are tests for the possible endless loop patterns and for the false pattern described above.

Fixes #145 