### PR TITLE
Make scope capture substitution regex global

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -54,7 +54,7 @@ export function basename(path: string): string {
 	}
 }
 
-let CAPTURING_REGEX_SOURCE = /\$(\d+)|\${(\d+):\/(downcase|upcase)}/;
+let CAPTURING_REGEX_SOURCE = /\$(\d+)|\${(\d+):\/(downcase|upcase)}/g;
 
 export class RegexSource {
 
@@ -62,6 +62,7 @@ export class RegexSource {
 		if (regexSource === null) {
 			return false;
 		}
+		CAPTURING_REGEX_SOURCE.lastIndex = 0;
 		return CAPTURING_REGEX_SOURCE.test(regexSource);
 	}
 

--- a/test-cases/suite1/fixtures/147.grammar.json
+++ b/test-cases/suite1/fixtures/147.grammar.json
@@ -1,0 +1,9 @@
+{
+	"scopeName": "source.test",
+	"patterns": [
+		{
+			"match": "\\b(?i:function)\\b",
+			"name": "storage.type.$0 keyword.declaration.$0"
+		}
+	]
+}

--- a/test-cases/suite1/tests.json
+++ b/test-cases/suite1/tests.json
@@ -1806,5 +1806,27 @@
 				]
 			}
 		]
+	},
+	{
+		"grammars": [
+			"fixtures/147.grammar.json"
+		],
+		"grammarPath": "fixtures/147.grammar.json",
+		"desc": "Issue #147",
+		"lines": [
+			{
+				"line": "Function",
+				"tokens": [
+					{
+						"value": "Function",
+						"scopes": [
+							"source.test",
+							"storage.type.Function",
+							"keyword.declaration.Function"
+						]
+					}
+				]
+			}
+		]
 	}
 ]


### PR DESCRIPTION
Add the global modifier to the regex that handles scope name capture substitutions for instances where more than one substitution exists.

Fixes #147