### PR TITLE
Fix elapsedmillis warning output

### DIFF
--- a/src/grammar.ts
+++ b/src/grammar.ts
@@ -887,7 +887,7 @@ function matchRule(grammar: Grammar, lineText: OnigString, isFirstLine: boolean,
 	if (DebugFlags.InDebugMode) {
 		const elapsedMillis = performanceNow() - perfStart;
 		if (elapsedMillis > 5) {
-			console.warn(`Rule ${rule.debugName} (${rule.id}) matching took ${elapsedMillis} against '${lineText}'`);
+			console.warn(`Rule: ${rule.debugName} (${rule.id}) matching took ${elapsedMillis} ms against |${lineText.content.replace(/\n$/, '\\n')}|`);
 		}
 		console.log(`  scanning for (linePos: ${linePos}, anchorPosition: ${anchorPosition})`);
 		console.log(debugCompiledRuleToString(ruleScanner));


### PR DESCRIPTION
The original elapsedmillis warning output (bug: `[object Object]`) looks like:
![bug](https://user-images.githubusercontent.com/43924785/164896856-dd406315-77ae-4130-a787-fc39718b0aff.jpg)

There is a typing issue in `Line 890 src/grammar.ts`. This output can be reproduced by: Then, `npm test`.
![reproduce_bug](https://user-images.githubusercontent.com/43924785/164897096-fdac6eab-c417-4a2c-b4f7-cfb59636ae9a.jpg)

After fixing the bug:
![after_fix](https://user-images.githubusercontent.com/43924785/164900042-c808d2c8-a76e-40f8-bf4e-a4c926a7d11d.jpg)

