### PR TITLE
Add JSON content detection to `parseRawGrammar`

### DIFF
--- a/src/parseRawGrammar.ts
+++ b/src/parseRawGrammar.ts
@@ -8,7 +8,7 @@ import { DebugFlags } from './debug';
 import { parseJSON } from './json';
 
 export function parseRawGrammar(content: string, filePath: string | null = null): IRawGrammar {
-	if (filePath !== null && /\.json$/.test(filePath)) {
+	if (!filePath && /^\s*\{.*\}\s*$/.test(content) || filePath !== null && /\.json$/.test(filePath)) {
 		return parseJSONGrammar(content, filePath);
 	}
 	return parsePLISTGrammar(content, filePath);


### PR DESCRIPTION
Fixes #214.

When there is no `.json` filepath, detect the enclosing object of a JSON grammar.