### PR TITLE
feat: add child combinator ">" (and fix a specificity bug)

### DIFF
--- a/src/tests/themes.test.ts
+++ b/src/tests/themes.test.ts
@@ -632,35 +632,6 @@ test('Theme resolving a rule with child combinator', () => {
 	assert.equal(match('c', 'b', 'd', 'a'), '#200000', 'c b d a');
 });
 
-// Bug 1 described in PR #233
-test('Theme resolving falls back to less specific rules (#233)', () => {
-	let theme = Theme.createFromRawTheme({
-		settings: [
-			{ settings: { foreground: '#100000' } },
-			{ scope: 'b a.b', settings: { foreground: '#200000' } },
-			{ scope: 'a', settings: { foreground: '#300000' } },
-		]
-	});
-
-	const colorMap = theme.getColorMap();
-	const match = (...path: string[]) => {
-		const result = theme.match(ScopeStack.from(...path));
-		if (!result || result.foregroundId === 0) {
-			return null;
-		}
-		return colorMap[result.foregroundId];
-	};
-
-	// Sanity check
-	assert.equal(match('b', 'a'), '#300000', 'b a');
-	assert.equal(match('b', 'a.b'), '#200000', 'b a.b');
-
-	// The main edge case. Although the "b a.b" rule exists, its parent scope doesn't
-	// match, so we need to fall back to the "a" rule.
-	assert.equal(match('c', 'a.b'), '#300000', 'c a.b');
-});
-
-// Bug 2 described in PR #233
 test('Theme resolving should give deeper scopes higher specificity (#233)', () => {
 	let theme = Theme.createFromRawTheme({
 		settings: [
@@ -682,14 +653,14 @@ test('Theme resolving should give deeper scopes higher specificity (#233)', () =
 	};
 
 	// Sanity check
-	assert.equal(match('x', 'a.b'), undefined, 'x a.b');
-	assert.equal(match('y', 'a.b'), undefined, 'y a.b');
-	assert.equal(match('y.z', 'a'), undefined, 'y.z a');
+	assert.equal(match('x', 'a.b'), null, 'x a.b');
+	assert.equal(match('y', 'a.b'), null, 'y a.b');
+	assert.equal(match('y.z', 'a'), null, 'y.z a');
 	assert.equal(match('x', 'y', 'a.b'), '#300000', 'x y a.b');
 
 	// Even though the "x y a.b" rule has more scopes in its path, the "y.z a.b" rule has
 	// a deeper match, so it should take precedence.
-	assert.equal(match('y.z', 'a.b'), '#200000', 'y.z a.b');
+	assert.equal(match('x', 'y.z', 'a.b'), '#200000', 'y.z a.b');
 });
 
 test('Theme resolving issue #38: ignores rules with invalid colors', () => {

--- a/src/tests/themes.test.ts
+++ b/src/tests/themes.test.ts
@@ -606,6 +606,92 @@ test('Theme resolving rules with parent scopes', () => {
 	assertThemeEqual(actual, expected);
 });
 
+test('Theme resolving a rule with child combinator', () => {
+	let theme = Theme.createFromRawTheme({
+		settings: [
+			{ settings: { foreground: '#100000' } },
+			{ scope: 'b a', settings: { foreground: '#200000' } },
+			{ scope: 'b > a', settings: { foreground: '#300000' } },
+			{ scope: 'c > b > a', settings: { foreground: '#400000' } },
+			{ scope: 'a', settings: { foreground: '#500000' } },
+		]
+	});
+
+	const colorMap = theme.getColorMap();
+	const match = (...path: string[]) => {
+		const result = theme.match(ScopeStack.from(...path));
+		if (!result) {
+			return null;
+		}
+		return colorMap[result.foregroundId];
+	};
+
+	assert.equal(match('b', 'a'), '#300000', 'b a');
+	assert.equal(match('b', 'c', 'a'), '#200000', 'b c a');
+	assert.equal(match('c', 'b', 'a'), '#400000', 'c b a');
+	assert.equal(match('c', 'b', 'd', 'a'), '#200000', 'c b d a');
+});
+
+// Bug 1 described in PR #233
+test('Theme resolving falls back to less specific rules (#233)', () => {
+	let theme = Theme.createFromRawTheme({
+		settings: [
+			{ settings: { foreground: '#100000' } },
+			{ scope: 'b a.b', settings: { foreground: '#200000' } },
+			{ scope: 'a', settings: { foreground: '#300000' } },
+		]
+	});
+
+	const colorMap = theme.getColorMap();
+	const match = (...path: string[]) => {
+		const result = theme.match(ScopeStack.from(...path));
+		if (!result || result.foregroundId === 0) {
+			return null;
+		}
+		return colorMap[result.foregroundId];
+	};
+
+	// Sanity check
+	assert.equal(match('b', 'a'), '#300000', 'b a');
+	assert.equal(match('b', 'a.b'), '#200000', 'b a.b');
+
+	// The main edge case. Although the "b a.b" rule exists, its parent scope doesn't
+	// match, so we need to fall back to the "a" rule.
+	assert.equal(match('c', 'a.b'), '#300000', 'c a.b');
+});
+
+// Bug 2 described in PR #233
+test('Theme resolving should give deeper scopes higher specificity (#233)', () => {
+	let theme = Theme.createFromRawTheme({
+		settings: [
+			{ settings: { foreground: '#100000' } },
+			{ scope: 'y.z a.b', settings: { foreground: '#200000' } },
+			{ scope: 'x y a.b', settings: { foreground: '#300000' } },
+		]
+	});
+
+	const colorMap = theme.getColorMap();
+	const defaults = theme.getDefaults();
+
+	const match = (...path: string[]) => {
+		const result = theme.match(ScopeStack.from(...path));
+		if (!result || result.foregroundId === 0) {
+			return null;
+		}
+		return colorMap[result.foregroundId];
+	};
+
+	// Sanity check
+	assert.equal(match('x', 'a.b'), undefined, 'x a.b');
+	assert.equal(match('y', 'a.b'), undefined, 'y a.b');
+	assert.equal(match('y.z', 'a'), undefined, 'y.z a');
+	assert.equal(match('x', 'y', 'a.b'), '#300000', 'x y a.b');
+
+	// Even though the "x y a.b" rule has more scopes in its path, the "y.z a.b" rule has
+	// a deeper match, so it should take precedence.
+	assert.equal(match('y.z', 'a.b'), '#200000', 'y.z a.b');
+});
+
 test('Theme resolving issue #38: ignores rules with invalid colors', () => {
 	let actual = parseTheme({
 		settings: [{

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -192,6 +192,7 @@ function _scopePathMatchesParentScopes(scopePath: ScopeStack | null, parentScope
 		if (!scopePath) {
 			return false;
 		}
+		scopePath = scopePath.parent;
 	}
 
 	// All parent scopes were matched.

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -166,6 +166,7 @@ function _scopePathMatchesParentScopes(scopePath: ScopeStack | null, parentScope
 		return true;
 	}
 
+	// Starting with the deepest parent scope, look for a match in the scope path.
 	for (let index = 0; index < parentScopes.length; index++) {
 		let scopePattern = parentScopes[index];
 		let scopeMustMatch = false;
@@ -173,6 +174,7 @@ function _scopePathMatchesParentScopes(scopePath: ScopeStack | null, parentScope
 		// Check for a child combinator (a parent-child relationship)
 		if (scopePattern === '>') {
 			if (index === parentScopes.length - 1) {
+				// Invalid use of child combinator
 				return false;
 			}
 			scopePattern = parentScopes[++index];
@@ -184,12 +186,14 @@ function _scopePathMatchesParentScopes(scopePath: ScopeStack | null, parentScope
 				break;
 			}
 			if (scopeMustMatch) {
+				// If a child combinator was used, the parent scope must match.
 				return false;
 			}
-			scopePath = scopePath.parent
+			scopePath = scopePath.parent;
 		}
 
 		if (!scopePath) {
+			// No more potential matches
 			return false;
 		}
 		scopePath = scopePath.parent;
@@ -541,11 +545,11 @@ export class ThemeTrieElement {
 			// When sorting by scope name specificity, it's safe to treat a longer parent
 			// scope as more specific. If both rules' parent scopes match a given scope
 			// path, the longer parent scope will always be more specific.
-			const parentScopeLengthDelta =
+			const parentScopeLengthDiff =
 				b.parentScopes[bParentIndex].length - a.parentScopes[aParentIndex].length;
 
-			if (parentScopeLengthDelta !== 0) {
-				return parentScopeLengthDelta;
+			if (parentScopeLengthDiff !== 0) {
+				return parentScopeLengthDiff;
 			}
 
 			aParentIndex++;

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -547,6 +547,9 @@ export class ThemeTrieElement {
 			if (parentScopeLengthDelta !== 0) {
 				return parentScopeLengthDelta;
 			}
+
+			aParentIndex++;
+			bParentIndex++;
 		}
 
 		// If a depth-first, scope-by-scope comparison resulted in a tie, the rule with

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -562,7 +562,6 @@ export class ThemeTrieElement {
 	}
 
 	public match(scope: ScopeName): ThemeTrieElementRule[] {
-		let childRules: ThemeTrieElementRule[] | undefined;
 		if (scope !== '') {
 			let dotIndex = scope.indexOf('.')
 			let head: string
@@ -576,17 +575,13 @@ export class ThemeTrieElement {
 			}
 
 			if (this._children.hasOwnProperty(head)) {
-				childRules = this._children[head].match(tail);
+				return this._children[head].match(tail);
 			}
 		}
 
-		const rules = [this._mainRule].concat(this._rulesWithParentScopes);
+		const rules = this._rulesWithParentScopes.concat(this._mainRule);
 		rules.sort(ThemeTrieElement._cmpBySpecificity);
-
-		// If an element exists for a deeper scope, its rule specificity is greater than
-		// the current element, but we still need to return the current element's rules in
-		// case none of the deeper elements match (due to parent scope requirements).
-		return childRules ? childRules.concat(rules) : rules;
+		return rules;
 	}
 
 	public insert(scopeDepth: number, scope: ScopeName, parentScopes: ScopeName[] | null, fontStyle: number, foreground: number, background: number): void {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -105,7 +105,7 @@ export function strcmp(a: string, b: string): number {
 	return 0;
 }
 
-export function strArrCmp(a: string[] | null, b: string[] | null): number {
+export function strArrCmp(a: readonly string[] | null, b: readonly string[] | null): number {
 	if (a === null && b === null) {
 		return 0;
 	}


### PR DESCRIPTION
Closes #123

- Feature: Add support for the child combinator (the `>` operator). This allows for styling a parent-child relationship specifically.

  https://github.com/microsoft/vscode-textmate/blob/d63ed169dfa50fe337d6985b658103cb47829abe/src/theme.ts#L173-L180

  https://github.com/microsoft/vscode-textmate/blob/d63ed169dfa50fe337d6985b658103cb47829abe/src/theme.ts#L526-L532

- Bug: If the number of scope names in both rules‘ scope paths are not equal, the parent scope names won‘t be compared at all. Instead, the rule with the longest scope path is preferred. This goes against the TextMate manual (https://macromates.com/manual/en/scope_selectors). In particular, the following line in “Ranking Matches”:
  > Rules 1 and 2 applied again to the scope selector when removing the deepest element (in the case of a tie)

  https://github.com/microsoft/vscode-textmate/blob/09effd8b7429b71010e0fa34ea2e16e622692946/src/theme.ts#L506-L515

  **How did I fix it?**  
  Do a depth-first, scope-by-scope comparison of the parent scopes, even if one of the rules has a longer scope path.

  https://github.com/microsoft/vscode-textmate/blob/7c14889ce5b178313f13bc0ef1d1e06d3541ffcc/src/theme.ts#L539-L553

## Tests

- Child combinators
  https://github.com/microsoft/vscode-textmate/blob/7c14889ce5b178313f13bc0ef1d1e06d3541ffcc/src/tests/themes.test.ts#L609
- Bug
  https://github.com/microsoft/vscode-textmate/blob/7c14889ce5b178313f13bc0ef1d1e06d3541ffcc/src/tests/themes.test.ts#L635