### PR TITLE
Expose EncodedTokenAttributes in main.ts

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,7 @@ import { applyStateStackDiff, diffStateStacksRefEq, StackDiff } from './diffStat
 export * from './onigLib';
 
 export { IRawGrammar, IRawTheme };
+export { EncodedTokenAttributes } from './encodedTokenAttributes';
 
 /**
  * A registry helper that can locate grammar file paths given scope names.


### PR DESCRIPTION
Without this, there is no way to use `IGrammar.tokenizeLine2` without redefining the EncodedTokenDataConsts and reimplementing the functions.

See for example:
https://github.com/microsoft/vscode/blob/8810d514c7452ce912bd9bc6f79a3429cc55dcdd/src/vs/editor/common/encodedTokenAttributes.ts#L101-L103