### PR TITLE
9.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-textmate",
-  "version": "9.1.0",
+  "version": "9.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-textmate",
-      "version": "9.1.0",
+      "version": "9.2.0",
       "license": "MIT",
       "devDependencies": {
         "@microsoft/api-extractor": "^7.48.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-textmate",
-  "version": "9.1.0",
+  "version": "9.2.0",
   "description": "VSCode TextMate grammar helpers",
   "author": {
     "name": "Microsoft Corporation"


### PR DESCRIPTION
Version bump for the api-extractor changes. Tested using npm link against vscode and by running our full build pipeline