### PR TITLE
Update README with textmate-validate mention

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ Tokenizing line: }
 
 ## For grammar authors
 
-See [vscode-tmgrammar-test](https://github.com/PanAeon/vscode-tmgrammar-test) that can help you write unit tests against your grammar.
+- [vscode-tmgrammar-test](https://github.com/PanAeon/vscode-tmgrammar-test) - for writing unit tests against a grammar
+- [textmate-validate](https://github.com/carlwr/textmate-validate) - for linting the regexes of a grammar using `vscode-textmate`'s regex engine
 
 ## API doc
 


### PR DESCRIPTION
Extend _For grammar authors_ to also mention https://github.com/carlwr/textmate-validate; a tool complementing the already-mentioned https://github.com/PanAeon/vscode-tmgrammar-test.

`textmate-validate` uses the Oniguruma wasm of `vscode-textmate` to exercise all regexes in a grammar.

---

Disclosures:
- I am the author of `textmate-validate`
- I am a human, and `textmate-validate` was written by me; not by agents